### PR TITLE
Make linting and formatting one command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,11 @@ docker-compose -f dev-docker-compose.yml up -d
 
 ### Linting the Project
 
-Run the following to format the project
-
-```bash
-npm run format
-```
-
-Run the following command to lint the project
+Run the following to lint and format the project
 
 ```bash
 npm run lint
 ```
-
-Use `--fix` to make eslint run any fixes available
 
 ### Development environment variable
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "dev": "next dev",
         "build": "next build",
         "start": "next start",
-        "lint": "next lint && prettier . --write",
+        "lint": "next lint --fix && prettier . --write",
         "prepare": "husky install"
     },
     "dependencies": {


### PR DESCRIPTION
## Description:

Make linting and formatting one command: `npm run lint`

## Related Issues:

Closes #99 

## Checklist:

Before submitting this pull request, please make sure of the following:

-   [x] My code follows the style guidelines of this project
-   [x] My changes generate no new warnings
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
    -   [ ] Are there representative cases to test the program?
    -   [ ] Are there tests for edge cases? (empty strings, negatives, infinity, off-by-one errors, etc.)
-   [x] New and existing unit tests pass locally with my changes
-   [x] I have resolved any merge conflicts with the latest `master` branch.
-   [x] I have labeled my PR
-   [x] I have assigned myself to the PR

