### PR TITLE
Get rid of HTML form validator when missing email address

### DIFF
--- a/src/components/LoginForm/index.tsx
+++ b/src/components/LoginForm/index.tsx
@@ -52,7 +52,7 @@ export default function LoginForm() {
                 <Typography data-cy='title' variant='h4' sx={{ fontWeight: 'medium' }}>
                     Login
                 </Typography>
-                <form onSubmit={formik.handleSubmit}>
+                <form onSubmit={formik.handleSubmit} noValidate>
                     <Box
                         gap={1}
                         sx={{

--- a/src/components/SignUpForm/index.tsx
+++ b/src/components/SignUpForm/index.tsx
@@ -54,7 +54,7 @@ export default function SignUpForm() {
                 <Typography data-cy='title' variant='h4' sx={{ fontWeight: 'medium' }}>
                     Sign Up
                 </Typography>
-                <form onSubmit={formik.handleSubmit}>
+                <form onSubmit={formik.handleSubmit} noValidate>
                     <Box
                         gap={1}
                         sx={{


### PR DESCRIPTION
## Description:

**Problem:**
The HTML form validator pops up when the email is missing an '@' sign. We only want our custom validation, and not the form validator.

**Solution:**
Added 'noValidate' to get rid of HTML form validation and only have our custom validation.

<img width="1710" alt="Screenshot 2023-11-06 at 13 14 45" src="https://github.com/COSC-499-W2023/year-long-project-team-3/assets/77898527/f58055cb-41cf-461c-96f7-242cb0a6c7f5">

## Related Issues:

#143 

## Checklist:

Before submitting this pull request, please make sure of the following:

-   [ ] My code follows the style guidelines of this project
-   [x] My changes generate no new warnings
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
    -   [ ] Are there representative cases to test the program?
    -   [ ] Are there tests for edge cases? (empty strings, negatives, infinity, off-by-one errors, etc.)
-   [x] New and existing unit tests pass locally with my changes
-   [x] I have resolved any merge conflicts with the latest `master` branch.
-   [x] I have labeled my PR
-   [x] I have assigned myself to the PR
-   [ ] I have run the E2E tests on my branch

## Screenshots or Visual Changes (if applicable):

<img width="1710" alt="Screenshot 2023-11-06 at 13 19 45" src="https://github.com/COSC-499-W2023/year-long-project-team-3/assets/77898527/bb12491c-1203-40a1-895c-60e0a8956f22">

## Documentation

Link to documentation if pages were added or changed.
