### PR TITLE
Dashboard tab can be selected via url search param

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -13,9 +13,11 @@ import VideoList from '@/components/VideoList'
 import SubmissionBoxList from '@/components/SubmissionBoxList'
 import DashboardSearchBar from '@/components/DashboardSearchBar'
 import { VideoSubmission } from '@/app/api/my-videos/route'
+import { useSearchParams } from 'next/navigation'
 
 export default function DashboardPage() {
     const session = useSession()
+    const queriedTab = useSearchParams().get('tab')
 
     // Videos
     const [allVideos, setAllVideos] = useState<(Video & VideoSubmission)[]>([])
@@ -27,7 +29,7 @@ export default function DashboardPage() {
     const [tempSubmissionBoxes, setTempSubmissionBoxes] = useState<SubmissionBox[]>([])
 
     // Page component controls
-    const [sidebarSelectedOption, setSidebarSelectedOption] = useState<SidebarOption>('menu_my_videos')
+    const [sidebarSelectedOption, setSidebarSelectedOption] = useState<SidebarOption>(queryParamToSidebarOption(queriedTab))
     const [pageTitle, setPageTitle] = useState('My Videos')
     const [isVideoTabSelected, setIsVideoTabSelected] = useState(true)
 
@@ -222,5 +224,14 @@ export default function DashboardPage() {
         const response = await fetch('/api/submission-box/requestedsubmissions')
         const { submissionBoxes } = await response.json()
         return submissionBoxes
+    }
+}
+
+function queryParamToSidebarOption(queryParam: string | null): SidebarOption {
+    switch (queryParam?.toLowerCase()) {
+    case 'my-videos': return 'menu_my_videos'
+    case 'my-invitations': return 'submission_boxes_my_invitations'
+    case 'manage-boxes': return 'submission_boxes_manage_boxes'
+    default: return 'menu_my_videos'
     }
 }


### PR DESCRIPTION
## Description:

Going to a url like `/dashboard?tab=my-invitations` now opens the dashboard page to that tab

## Related Issues:

Closes #480 

## Checklist:

Before submitting this pull request, please make sure of the following:

-   [x] My code follows the style guidelines of this project
-   [x] My changes generate no new warnings
-   [x] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
    -   [ ] Are there representative cases to test the program?
    -   [ ] Are there tests for edge cases? (empty strings, negatives, infinity, off-by-one errors, etc.)
-   [x] New and existing unit tests pass locally with my changes
-   [x] I have resolved any merge conflicts with the latest `master` branch.
-   [x] I have labeled my PR
-   [x] I have assigned myself to the PR

