### PR TITLE
Fix Prisma Command for Preview

### DIFF
--- a/.github/workflows/e2e_tests_preview.yml
+++ b/.github/workflows/e2e_tests_preview.yml
@@ -2,7 +2,7 @@ name: Cypress E2E Tests (Preview Deployment)
 
 on:
     pull_request:
-        types: [ready_for_review, synchronize]
+        types: [ready_for_review, synchronize, opened]
         paths-ignore:
             - docs/**
             - '**.md'


### PR DESCRIPTION
### Description
- Currently, if someone alters the database schema, when the tests run, their migration is applied to the preview database. As we were not previously resetting the database, if someone else then tries to run a different branch without the updated schema on preview, their tests will fail.
- This changes the command run so a full reset is done, ie all data dropped and migrations applied to an empty database.
- I also fixed the E2E test triggers, so if you open a PR that is not a draft they will run automatically.