### PR TITLE
Make VideoList not move the page

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -166,6 +166,7 @@ export default function DashboardPage() {
                                     width: '100%',
                                     overflowY: 'auto',
                                     paddingTop: 2,
+                                    maxHeight: 'calc(100vh - 170px)',
                                 }}
                             >
                                 {isVideoTabSelected ? (


### PR DESCRIPTION
## Description:

Video List is overflowing the page

Seth and Justin failed to fix this earlier

## Related Issues:

Closes #500 

## Checklist:

Before submitting this pull request, please make sure of the following:

-   [ ] My code follows the style guidelines of this project
-   [ ] My changes generate no new warnings
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
    -   [ ] Are there representative cases to test the program?
    -   [ ] Are there tests for edge cases? (empty strings, negatives, infinity, off-by-one errors, etc.)
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] I have resolved any merge conflicts with the latest `master` branch.
-   [ ] I have labeled my PR
-   [ ] I have assigned myself to the PR

## Screenshots or Visual Changes (if applicable):

https://github.com/COSC-499-W2023/year-long-project-team-3/assets/35695324/d9af3bc4-dfcf-4868-8c36-1f7e91c0d72c


