### PR TITLE
Hide Video Submission Button If Not Video Owner

### DIFF
--- a/src/app/video/[videoId]/page.tsx
+++ b/src/app/video/[videoId]/page.tsx
@@ -78,7 +78,7 @@ export default function VideoDetailedPage({ params }: VideoDetailedPageProps) {
         setTitleEdit(video.title)
         setDescriptionEdit(video?.description ?? '')
         setIsOwner(video?.ownerId === userId)
-    }, [video])
+    }, [video, userId])
 
     useEffect(() => {
         setIsFetchingVideo(true)


### PR DESCRIPTION
## Description:

- Users who are not the video owner can see the button to submit a video to a submission box when they view it.
- I added a useState to store if the person viewing the page is the video owner. This was already checked to see if they could edit it.

## Related Issues:

- #540

## Checklist:

Before submitting this pull request, please make sure of the following:

-   [ ] My code follows the style guidelines of this project
-   [ ] My changes generate no new warnings
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
    -   [ ] Are there representative cases to test the program?
    -   [ ] Are there tests for edge cases? (empty strings, negatives, infinity, off-by-one errors, etc.)
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] I have resolved any merge conflicts with the latest `master` branch.
-   [ ] I have labeled my PR
-   [ ] I have assigned myself to the PR

## Screenshots or Visual Changes (if applicable):

- Video in submission box:

![image](https://github.com/COSC-499-W2023/year-long-project-team-3/assets/83678885/9097b5aa-6a9f-43f5-86a9-474d8df697c3)

- Video you own

![image](https://github.com/COSC-499-W2023/year-long-project-team-3/assets/83678885/d8040e3b-c7e2-4842-95c8-36104aad6668)


## Documentation

- N/A

