### PR TITLE
Fix Incorrect Toast Message on Password Reset

### DIFF
--- a/src/components/ResetPasswordForm/index.tsx
+++ b/src/components/ResetPasswordForm/index.tsx
@@ -142,7 +142,7 @@ export default function ResetPasswordEmailAddressForm(props: {resetPasswordId: s
                 }),
             })
 
-            if (response.status == 201) {
+            if (response.status == 200) {
                 toast.success('Password has been reset.')
                 logger.info('Reset password')
             } else {


### PR DESCRIPTION
## Description:

- The wrong toast message was being printed when the user successfully resets their password.
- The issue was the front-end component was expecting the wrong status code from the API when the password was successfully updated.

## Related Issues:

- #542 

## Checklist:

Before submitting this pull request, please make sure of the following:

-   [x] My code follows the style guidelines of this project
-   [x] My changes generate no new warnings
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] I have made corresponding changes to the documentation
-   [x] I have added tests that prove my fix is effective or that my feature works
    -   [x] Are there representative cases to test the program?
    -   [x] Are there tests for edge cases? (empty strings, negatives, infinity, off-by-one errors, etc.)
-   [x] New and existing unit tests pass locally with my changes
-   [x] I have resolved any merge conflicts with the latest `master` branch.
-   [x] I have labeled my PR
-   [x] I have assigned myself to the PR

## Screenshots or Visual Changes (if applicable):

N/A

## Documentation

N/A