### PR TITLE
Fix Bug With Submission Box Cards

### DIFF
--- a/src/app/api/submission-box/myboxes/route.ts
+++ b/src/app/api/submission-box/myboxes/route.ts
@@ -39,9 +39,6 @@ export async function GET(_: NextRequest): Promise<NextResponse> {
                     },
                     include: {
                         requestedSubmissions: {
-                            where: {
-                                userId: userId,
-                            },
                             include: {
                                 videoVersions: {
                                     select: {


### PR DESCRIPTION
## Description:

- Submission box cards were not displaying the information about requested submissions properly.
- This was due to an issue with the `myBoxes` API. It was filtering requested submissions by the user ID of the box owner, so it was not getting any of the requested submissions, as they all belonged to other users.

## Related Issues:

- #544 

## Checklist:

Before submitting this pull request, please make sure of the following:

-   [ ] My code follows the style guidelines of this project
-   [ ] My changes generate no new warnings
-   [ ] I have performed a self-review of my code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] I have added tests that prove my fix is effective or that my feature works
    -   [ ] Are there representative cases to test the program?
    -   [ ] Are there tests for edge cases? (empty strings, negatives, infinity, off-by-one errors, etc.)
-   [ ] New and existing unit tests pass locally with my changes
-   [ ] I have resolved any merge conflicts with the latest `master` branch.
-   [ ] I have labeled my PR
-   [ ] I have assigned myself to the PR

## Screenshots or Visual Changes (if applicable):

![image](https://github.com/COSC-499-W2023/year-long-project-team-3/assets/83678885/59c2a738-fb9c-418e-aca0-be75e822ad8f)


## Documentation

- N/A